### PR TITLE
fix: unable to connect Canvas cards when the toolbar is in `Top (fixed)` position #415

### DIFF
--- a/src/Toolbar/ToolbarRenderer.ts
+++ b/src/Toolbar/ToolbarRenderer.ts
@@ -1,6 +1,6 @@
 import { Rect } from "@codemirror/view";
 import NoteToolbarPlugin from "main";
-import { FrontMatterCache, getIcon, ItemView, MarkdownView, Menu, MenuItem, MenuPositionDef, Notice, Platform, setIcon, setTooltip, TFile, TFolder } from "obsidian";
+import { CanvasView, FrontMatterCache, getIcon, ItemView, MarkdownView, Menu, MenuItem, MenuPositionDef, Notice, Platform, setIcon, setTooltip, TFile, TFolder } from "obsidian";
 import { DefaultStyleType, ItemType, LocalVar, MobileStyleType, OBSIDIAN_UI_ELEMENTS, PositionType, t, ToggleUiStateType, ToolbarSettings, ToolbarStyle } from "Settings/NoteToolbarSettings";
 import ToolbarSettingsModal from "Settings/UI/Modals/ToolbarSettingsModal";
 import { calcComponentVisToggles, getViewId, hasStyle, isValidUri, putFocusInMenu } from "Utils/Utils";
@@ -276,10 +276,19 @@ export default class ToolbarRenderer {
             }
             case PositionType.Top: {
                 const viewHeader = viewEl?.querySelector('.view-header') as HTMLElement;
+				// fix: (#415) unable to connect Canvas cards when the toolbar is in Top (fixed) position
+				const updateCanvasViewportCache = () => {
+					if (!view.leaf.isDeferred && view.getViewType() == 'canvas') {
+						(view as CanvasView).canvas?.onResize();
+					}
+				};
                 // FIXME: add to modal header, but this is causing duplicate toolbars
                 // if (modalEl) viewHeader = modalEl.querySelector('.modal-header') as HTMLElement;
-                if (viewHeader) viewHeader.insertAdjacentElement(Platform.isPhone ? 'beforebegin' : 'afterend', embedBlock)
-					else this.ntb.debug("🛑 renderToolbar: Unable to find .view-header to insert toolbar");
+                if (viewHeader) {
+					viewHeader.insertAdjacentElement(Platform.isPhone ? 'beforebegin' : 'afterend', embedBlock);
+					if (!Platform.isPhone) updateCanvasViewportCache();
+				}
+				else this.ntb.debug("🛑 renderToolbar: Unable to find .view-header to insert toolbar");
 				// update height for header repositioning on phones
 				if (Platform.isPhone) {
 					const setToolbarHeight = () => {
@@ -287,6 +296,7 @@ export default class ToolbarRenderer {
 						if (height === 0) return;
 						activeDocument.body.style.setProperty('--ntb-toolbar-height', `${height}px`);
 						this.phoneTbarHeightCache.set(toolbar.uuid, { height, timestamp: toolbar.updated });
+						updateCanvasViewportCache();
 					};
 					embedBlock.addEventListener('transitionend', setToolbarHeight);
 					// fallback: if no transition fires (e.g. on restart), read height after layout settles

--- a/src/Types/types.d.ts
+++ b/src/Types/types.d.ts
@@ -47,6 +47,13 @@ declare module "obsidian" {
         }
     }
 
+    interface CanvasView extends TextFileView {
+        canvas: {
+            // allows us to update viewport dimension cache of the CanvasView
+            onResize(): void;
+        }
+    }
+
     /** internal chooser API used by SuggestModal */
     interface ChooserType<T> {
         values: T[];


### PR DESCRIPTION
`CanvasView` caches its viewport dimension on the first load and when it gets resized. Therefore, we need to update the cache after inserting a toolbar by calling `canvasView.canvas.resize()`.

- [x] Tested on desktop
- [x] Tested on mobile (using `app.emulateMobile(true)`)

Before:
<img width="640" height="468" alt="before-fix" src="https://github.com/user-attachments/assets/2ab2ae2d-1699-403d-b84c-5153b78a9342" />

After:
<img width="640" height="442" alt="after-fix" src="https://github.com/user-attachments/assets/d7b5aa50-a093-4dda-aee0-2e806723250f" />

